### PR TITLE
Use OkHttp3 instead of java.net.http.HttpClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation "com.github.KyleLearnedThis:KotlinDS:1.0.3"
     implementation "io.reactivex.rxjava2:rxkotlin:2.4.0"
     implementation "com.google.code.gson:gson:2.8.6"
+    implementation("com.squareup.okhttp3:okhttp:4.6.0")
     implementation "com.squareup.retrofit2:retrofit:2.7.1"
     implementation "com.squareup.retrofit2:retrofit:2.7.1"
     implementation "com.squareup.retrofit2:adapter-rxjava2:2.7.1"

--- a/src/main/kotlin/com/albion/labs/network/basic/HttpClientExample.kt
+++ b/src/main/kotlin/com/albion/labs/network/basic/HttpClientExample.kt
@@ -4,19 +4,22 @@ import com.albion.labs.network.data.ChuckNorrisJoke
 import com.google.gson.Gson
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
 
 class HttpClientExample {
     fun httpGet(urlString: String): String {
-        val client = HttpClient.newBuilder().build()
-        val request = HttpRequest.newBuilder()
-                .uri(URI(urlString))
+        val client = OkHttpClient()
+        val request: Request = Request.Builder()
+                .url(urlString)
                 .build()
-        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-        return response.body().toString()
+        val call: Call = client.newCall(request)
+        val response: Response = call.execute()
+        val body = response.body!!
+        return body.string()
     }
 
     fun rxHttpGet(urlString: String) {


### PR DESCRIPTION
Since java.net.http.HttpClient is JDK version dependent (JDK 11+)
And I would like to use JDK 1.8 as default because of Android